### PR TITLE
Display last month activities

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,7 +8,7 @@ from pyfonts import load_font
 #---------------------------------------------------------------
 #Configs and functions -----------------------------------------
 st.set_page_config(
-    page_title="Year in Sports",
+    page_title="Last Month in Sports",
     page_icon="weight_lifter",
     #layout="wide",
      )
@@ -73,161 +73,61 @@ def convert_time(sec):
 #process data for chart
 def process_data(df):
 
-    #prepare data for analysis----------------------------
-    df_filtered = df[df["Activity Date"].dt.year == year_filter]
+    #find last month in dataset
+    last_date = df["Activity Date"].max()
+    start_month = last_date.replace(day=1)
+    df_filtered = df[(df["Activity Date"] >= start_month) & (df["Activity Date"] <= last_date)]
 
-    #get max top 3 activity types by count
-    top_three = df_filtered["Activity Type"].value_counts().head(3).index.to_list()
+    #get activity types
+    top_three = df_filtered["Activity Type"].value_counts().index.to_list()
 
-    #derive clean column for activity types to use later
-    df_filtered["Activity Type clean"] = [activity if activity in top_three else "Other"
-                                            for activity in df_filtered['Activity Type']]
-    df_filtered["Activity rank"] = df_filtered["Activity Type"].map(
-        dict(zip(top_three, np.arange(0,len(top_three),1)))
-        ).fillna(len(top_three))
+    activity_data = {}
+    for act in top_three:
+        sub = df_filtered[df_filtered["Activity Type"] == act]
+        daily = sub.groupby(sub["Activity Date"].dt.date).agg({"Distance": "sum", "Moving Time": "sum"}).reset_index()
+        activity_data[act] = daily
 
-    #pre-aggregate data---------------------------
-    #for daily circles
-    circles_df = df_filtered.groupby([df_filtered["Activity Date"].dt.month,
-                                df_filtered["Activity Date"].dt.day]).agg({'Activity Type clean': ','.join})
-    circles_df.index.names = ["Month", "Day"]
-    circles_df = circles_df.reset_index()
-    circles_df["Activity Type clean"] = [i.split(",") for i in circles_df["Activity Type clean"]]
-
-    #for small multiples
-    months = np.arange(1,13,1)
-    time_values = []
-    distance_values = []
-    for month in months:
-        time_values.append(df_filtered[(df_filtered["Activity Date"].dt.month == month)]["Moving Time"].sum())
-        if distance_unit=="Kilometers":
-            distance_values.append(df_filtered[(df_filtered["Activity Date"].dt.month == month)]["Distance"].sum()/1000)
-        elif distance_unit=="Miles":
-            distance_values.append(df_filtered[(df_filtered["Activity Date"].dt.month == month)]["Distance"].sum()/1600)
-        elif distance_unit=="Metres":
-            distance_values.append(df_filtered[(df_filtered["Activity Date"].dt.month == month)]["Distance"].sum())
-
-    #top three df
-    top_three_df = df_filtered[["Activity rank","Activity Type clean"]].value_counts().to_frame().reset_index().sort_values(by="Activity rank")
-
-    return df_filtered,top_three,top_three_df,circles_df,time_values,distance_values,months
+    return df_filtered, activity_data, last_date
 
 #create visual
-def create_visualisation(df_filtered,top_three,top_three_df,circles_df,time_values,distance_values,months):
+def create_visualisation(activity_data,last_date):
 
     #configs-------------------------------------
-    #colors
     act_color = ["#6DB4C8", "#FD7B5C", "#FBCA58", "#7E8384"]
-    act_colormap = dict(zip(top_three + ["Other"], act_color))
-    colors = {"bg": "#FBF9F5", "text":"#2E3234", "bars":"#C6C9CA"}
+    act_colormap = dict(zip(list(activity_data.keys()), act_color))
+    colors = {"bg": "#FBF9F5", "text":"#2E3234"}
 
-    #base size of circles
-    markersize = 80
-
-    #axis labels
-    month_labels = ['J', 'F', 'M', 'A', 'M', 'J', 'J', 'A', 'S', 'O', 'N', 'D']
-
-    #setup fig-------------------------------
-    fig = plt.figure(figsize=(10,12))
+    n = len(activity_data)
+    fig, axes = plt.subplots(n,1, figsize=(10,3*n), sharex=True)
     fig.set_facecolor(colors["bg"])
-    gs = GridSpec(5, 4, figure=fig)
-    ax1 = fig.add_subplot(gs[0:4, 0:3])
-    ax3 = fig.add_subplot(gs[3:4:, 3:])
-    if len(distance_values)!=0:
-        ax2 = fig.add_subplot(gs[2:3:, 3:])
-    plt.subplots_adjust(hspace=1, wspace=0.3)
-    for ax in fig.axes:
-        ax.set_facecolor(colors["bg"])
+    if n == 1:
+        axes = [axes]
 
-    #plot data -----------
-    #circles
-    for row in range(len(circles_df)):
-        for i,label in enumerate(circles_df.loc[row]["Activity Type clean"]):
-            if i==0:
-                ax1.scatter(x=circles_df.loc[row]["Month"],
-                    y=circles_df.loc[row]["Day"],
-                    s=15,
-                    linewidth=0,
-                    color=act_colormap[label],
-                    clip_on=False)
-            else:
-                ax1.scatter(x=circles_df.loc[row]["Month"],
-                    y=circles_df.loc[row]["Day"],
-                    s=(i**1.7)*markersize,
-                    color="None",
-                    edgecolor=act_colormap[label],
-                    linewidth=1.3,
-                    clip_on=False)
-                
-    #bar charts
-    if len(distance_values)!=0:
-        ax2.bar(months, distance_values, color=colors["bars"], zorder=3)
-    ax3.bar(months, time_values, color=colors["bars"], zorder=3)
-                
-    #format axis------------------
-    #circles
-    ax1.set_xticks(np.arange(1,13,1))
-    ax1.set_yticks(np.arange(1,32,1))
-    ax1.tick_params(axis="both", length=0, labeltop=True, labelbottom=False,)
-    ax1.set_yticklabels(labels=ax1.get_yticks(), fontproperties=font_r, fontsize=10, color=colors["text"])
-    ax1.set_xticklabels(labels=month_labels, fontproperties=font_r, fontsize=10,color=colors["text"])
-    ax1.set_xlim(xmin=0.3,xmax=12.5)
-    ax1.set_ylim(ymin=0,ymax=31)
-    ax1.invert_yaxis()
-    for pos in ["top", "bottom", "left", "right"]:
-        ax1.spines[pos].set_visible(False)
+    for ax,(act,df_line) in zip(axes, activity_data.items()):
+        ax.plot(pd.to_datetime(df_line["Activity Date"]), df_line["Moving Time"]/3600,
+                color=act_colormap.get(act,"#7E8384"), label=act)
+        ax.set_ylabel("Hours", fontproperties=font_r, color=colors["text"])
+        ax.legend(frameon=False, prop=font_m)
+        ax.grid(True, linestyle="--", linewidth=0.5, alpha=0.5)
+        for pos in ["top", "right"]:
+            ax.spines[pos].set_visible(False)
 
-    #distance
-    if len(distance_values)!=0:
-        ax2.locator_params(axis='y', nbins=4)
-        ax2.set_yticks(ax2.get_yticks())
-        distance_unit_display = distance_unit.replace("Kilometers","km").replace("Miles","m").replace("Metres","m")
-        ax2.set_yticklabels([""]+["{}{}".format(i.astype(int),distance_unit_display) for i in ax2.get_yticks()][1:],fontproperties=font_r, fontsize=9,color=colors["text"])
-        ax2.text(0,ax2.get_yticks()[-1]+ax2.get_yticks()[1], "Distance", fontsize=12, ha="left", va="center", fontproperties=font_m, color=colors["text"], alpha=0.9)
-        ax2.set_xticks(np.arange(1,13,1))
-        ax2.set_xticklabels(labels=month_labels, fontproperties=font_r, fontsize=10,color=colors["text"])
-        ax2.tick_params(axis="both", length=0,labelleft=False, labelright=True,)
-        ax2.grid(visible="True", axis='y', zorder=1, color=colors["text"], alpha=0.3, linewidth=0.5)
-        for pos in ["top", "left", "right"]:
-            ax2.spines[pos].set_visible(False)
+    axes[-1].set_xlabel("Date", fontproperties=font_r, color=colors["text"])
 
-    #total time
-    tick_steps = get_axis_ticks(max(time_values))
-    ax3.set_yticks(np.arange(0, max(time_values)+tick_steps, tick_steps))
-    ax3.set_yticklabels([""]+[convert_time(i) for i in ax3.get_yticks()][1:],fontproperties=font_r, fontsize=9,color=colors["text"])
-    ax3.text(0,max(time_values)+tick_steps, "Moving time", fontsize=12, ha="left", va="center", fontproperties=font_m, color=colors["text"], alpha=0.9)
-    ax3.set_xticks(np.arange(1,13,1))
-    ax3.set_xticklabels(labels=month_labels, fontproperties=font_r, fontsize=10,color=colors["text"])
-    ax3.tick_params(axis="both", length=0,labelleft=False, labelright=True,)
-    ax3.grid(visible="True", axis='y', zorder=1, color=colors["text"], alpha=0.3, linewidth=0.5)
-    for pos in ["top", "left", "right"]:
-        ax3.spines[pos].set_visible(False)
-
-    #legend--------------------------------
-    lg = fig.add_subplot(gs[0:2:, 3:])
-    labels = top_three_df["Activity Type clean"].to_list()
-    lg.barh(top_three_df["Activity rank"], top_three_df["count"], height=0.2, color=top_three_df["Activity Type clean"].map(act_colormap))
-    lg.set_ylim(ymin=-1.2,ymax=6)
-    lg.invert_yaxis()
-    lg.text(0, lg.get_ylim()[1], "Activities", fontsize=12, ha="left", va="bottom", fontproperties=font_m, color=colors["text"], alpha=0.9)
-    for i in range(len(top_three_df)):
-        lg.text(0.1, i-0.35, labels[i]+", "+str( top_three_df["count"][i]), fontsize=10.5, ha="left", va="center", fontproperties=font_r, color=colors["text"], alpha=0.9)
-    lg.axis("off")
-
-    #header and footer------------------------
-    plt.figtext(0.5,0.99,'My year in sports'.upper(), 
+    month_label = last_date.strftime("%B %Y")
+    plt.figtext(0.5,0.95,'My last month in sports'.upper(),
                 ha="center",
-                fontsize = 45, 
-                color=colors["text"], 
+                fontsize = 40,
+                color=colors["text"],
                 fontproperties=font_b)
-    plt.figtext(0.5,1.06,'{}'.format(year_filter), ha="center",fontsize = 25, color=colors["text"], alpha=0.95, fontproperties=font_r)
-    plt.figtext(0.5,0.19,'Data: Strava | Design: Lisa Hornung',ha="center", fontsize = 7, color=colors["text"], alpha=0.7,fontproperties=font_r)
+    plt.figtext(0.5,0.91,month_label, ha="center",fontsize = 20, color=colors["text"], alpha=0.95, fontproperties=font_r)
+    plt.figtext(0.5,0.05,'Data: Strava | Design: Lisa Hornung',ha="center", fontsize = 7, color=colors["text"], alpha=0.7,fontproperties=font_r)
 
     return fig
 
 #Main app--------------------------------------------------------
-st.title('My year in sports')
-st.markdown("#### Create a poster of all your Strava activities")
+st.title('My last month in sports')
+st.markdown("#### Visualise your most recent activities")
 st.write("")
 
 #upload data
@@ -309,27 +209,14 @@ st.sidebar.markdown("""
 #user inputs  
 if st.session_state["upload_success"]==True:
     with st.form(key='user_inputs'):
-        col1, col2 = st.columns(2)
-        with col1:
-            year_filter = st.selectbox(
-                "Year",
-                df["Activity Date"].dt.year.unique()
-                )
-        with col2:
-            distance_unit = st.selectbox(
-                "Distance unit",
-                ("N/A","Kilometers","Metres","Miles"),
-                help="Select 'N/A' if you don't want to visualise distance"
-                )
-        submitted = st.form_submit_button('Create visualisation',
-                                          on_click=form_submit_callback())
+        st.form_submit_button('Create visualisation', on_click=form_submit_callback())
 
 st.markdown("\n")
 
 #run visualisation
 if st.session_state["FormSubmitter:user_inputs-Create visualisation"] is not None:
-    df_filtered,top_three,top_three_df, circles_df,time_values,distance_values,months = process_data(df)
-    fig = create_visualisation(df_filtered,top_three,top_three_df,circles_df,time_values,distance_values,months)
+    df_filtered,activity_data,last_date = process_data(df)
+    fig = create_visualisation(activity_data,last_date)
     st.write(fig)
 
 
@@ -337,21 +224,21 @@ if st.session_state["FormSubmitter:user_inputs-Create visualisation"] is not Non
 if st.session_state["FormSubmitter:user_inputs-Create visualisation"] is not None:
     st.divider()
     st.write("")   
-    plt.savefig("my-year-in-sports.png", bbox_inches="tight", pad_inches=0.8)
-    with open("my-year-in-sports.png", "rb") as file:
+    plt.savefig("my-last-month-in-sports.png", bbox_inches="tight", pad_inches=0.8)
+    with open("my-last-month-in-sports.png", "rb") as file:
         btn = st.download_button(
                     label="Download image",
                     data=file,
-                    file_name="my-year-in-sports-{}.png".format(year_filter),
+                    file_name="my-last-month-in-sports.png",
                     mime="image/png"
                 )
 
-    plt.savefig("my-year-in-sports.svg",bbox_inches="tight", pad_inches=0.8)
-    with open("my-year-in-sports.svg", "rb") as file:
+    plt.savefig("my-last-month-in-sports.svg",bbox_inches="tight", pad_inches=0.8)
+    with open("my-last-month-in-sports.svg", "rb") as file:
         btn = st.download_button(
                     label="Download svg",
                     data=file,
-                    file_name="my-year-in-sports-{}.svg".format(year_filter),
+                    file_name="my-last-month-in-sports.svg",
                     mime="svg"
                 )
 


### PR DESCRIPTION
## Summary
- adjust page config for new monthly view
- filter data to last month and aggregate by activity type
- plot line charts per sport
- simplify user input and update download names

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_684409ba576483219c0465edf413f556